### PR TITLE
Support React v17 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.1",
+    "react-dom": "^16.0.0 || ^17.0.1"
   },
   "size-limit": [
     {


### PR DESCRIPTION
Currently, installing `prismic-reactjs-custom` in a React v17 project prints this error —

```
warning " > prismic-reactjs-custom@1.0.2" has incorrect peer dependency "react@^16.0.0".
warning " > prismic-reactjs-custom@1.0.2" has incorrect peer dependency "react-dom@^16.0.0".
```

I can confirm this project works with React v17, and I'm using it in production. This PR includes v17 in the supported versions of React in peer dependencies. I don't see any tests, but if you'd like, I can bump up the version in `devDependencies` as well.