### PR TITLE
ensure custom preformatted component is used if set

### DIFF
--- a/src/RichText.tsx
+++ b/src/RichText.tsx
@@ -38,6 +38,7 @@ export const RichText: FC<RichTextProps> = (props) =>
       heading5: props.heading5,
       heading6: props.heading6,
       paragraph: props.paragraph,
+      preformatted: props.preformatted,
       strong: props.strong,
       em: props.em,
       listItem: props.listItem,


### PR DESCRIPTION
👋  

When using a custom preformatted component I noticed it was rendering the default `pre` tag. It was missing in the options passed to `RichTextRenderer.render`